### PR TITLE
Knn weights speedup

### DIFF
--- a/ddop/newsvendor/_WeightedNewsvendor.py
+++ b/ddop/newsvendor/_WeightedNewsvendor.py
@@ -774,12 +774,9 @@ class KNeighborsWeightedNewsvendor(BaseWeightedNewsvendor):
 
     def _calc_weights(self, sample):
         neighbors = self.model_.kneighbors([sample], return_distance=False)[0]
+        weightsPos = np.array([1 / self.n_neighbors for i in range(len(neighbors))])
         
-        weights = np.array([1 / self.n_neighbors if i in neighbors else 0 for i in range(self.n_samples_)])
-        weightPosIndex = np.where(weights > 0)[0]
-        weightsPos = weights[weightPosIndex]
-        
-        return (weightsPos, weightPosIndex)
+        return (weightsPos, neighbors)
     
 
     def fit(self, X, y):
@@ -894,7 +891,9 @@ class GaussianWeightedNewsvendor(BaseWeightedNewsvendor):
             total = np.sum(distances_kernel_weighted)
 
         weights = distances_kernel_weighted / total
-
+        
+        # Actually unnecessary as all weights will be positive for the
+        # gaussian kernel anyway. Included only for the sake of code consistency.
         weightPosIndex = np.where(weights > 0)[0]
         weightsPos = weights[weightPosIndex]
 

--- a/ddop/newsvendor/_WeightedNewsvendor.py
+++ b/ddop/newsvendor/_WeightedNewsvendor.py
@@ -74,17 +74,19 @@ class BaseWeightedNewsvendor(BaseNewsvendor, DataDrivenMixin, ABC):
 
         y = self.y_
         q = []
-
+        
         for i in range(self.n_outputs_):
-            data = np.c_[weights, y[:, i]]
-            data = data[np.argsort(data[:, 1])]
-            sum_wi = 0
-            for row in data:
-                sum_wi = sum_wi + row[0]
-                if sum_wi >= self.cu_[i] / (self.cu_[i] + self.co_[i]):
-                    q.append(row[1])
-                    break
-
+            serviceLevel = self.cu_[i] / (self.cu_[i] + self.co_[i])
+            
+            indicesYSort = np.argsort(y[:, i])
+            ySorted = y[indicesYSort, i]
+            
+            distributionFunction = np.cumsum(weights[indicesYSort])
+            decisionIndex = np.where(distributionFunction >= serviceLevel)[0][0]
+            
+            q.append(ySorted[decisionIndex])
+        
+        
         return q
 
     def predict(self, X):


### PR DESCRIPTION
Slight adjustment by removing an unnecessary loop over the whole data set. Now the computation of the newsvendor using kNN takes only a few seconds instead of several minutes or even hours depending on the size of the considered data set.